### PR TITLE
Add true federated search mode with toggle

### DIFF
--- a/src/federated-search/components/ModeToggle.js
+++ b/src/federated-search/components/ModeToggle.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import styles from '../styles/ModeToggle.module.css'
+
+const modes = [
+  {
+    id: 'multi',
+    label: 'Multi-index',
+    description:
+      'Two independent searches run in parallel. Each index ranks its own results, displayed side by side.',
+  },
+  {
+    id: 'federated',
+    label: 'Federated',
+    description:
+      'A single search across both indexes. Meilisearch merges and re-ranks all results globally by relevance score.',
+  },
+]
+
+const ModeToggle = ({ mode, onChange }) => {
+  const current = modes.find(m => m.id === mode)
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.toggle}>
+        {modes.map(m => (
+          <button
+            key={m.id}
+            className={`${styles.option} ${mode === m.id ? styles.active : ''}`}
+            onClick={() => onChange(m.id)}
+          >
+            {m.label}
+          </button>
+        ))}
+      </div>
+      <p className={styles.description}>{current.description}</p>
+    </div>
+  )
+}
+
+export default ModeToggle

--- a/src/federated-search/components/Results/FederatedHit.js
+++ b/src/federated-search/components/Results/FederatedHit.js
@@ -1,0 +1,99 @@
+import React from 'react'
+import Genre from './Genre'
+import Director from './Director'
+import styles from '../../styles/FederatedHit.module.css'
+
+const Hl = ({ html }) => (
+  <span dangerouslySetInnerHTML={{ __html: html || '' }} />
+)
+
+const MovieHit = ({ hit }) => {
+  const fmt = hit._formatted || {}
+  return (
+    <>
+      <div className={styles.mainInfo}>
+        {hit.poster_path && (
+          <img
+            src={hit.poster_path}
+            alt={`${hit.title} poster`}
+            className={styles.image}
+          />
+        )}
+        <div className={styles.info}>
+          <span className={styles.title}>
+            <Hl html={fmt.title || hit.title} />
+          </span>
+          <Director crew={hit.crew} />
+          {hit.runtime && <div>{hit.runtime} min</div>}
+          <div className={styles.genres}>
+            <Genre genres={hit.genres} />
+          </div>
+        </div>
+      </div>
+      {fmt.overview && (
+        <div className={styles.overview}>
+          <Hl html={fmt.overview} />
+        </div>
+      )}
+    </>
+  )
+}
+
+const ActorHit = ({ hit }) => {
+  const fmt = hit._formatted || {}
+  const hasKnownFor = hit.known_for?.length > 0
+  return (
+    <div className={styles.mainInfo}>
+      {hit.profile_path && (
+        <img
+          src={hit.profile_path}
+          alt={`${hit.name} picture`}
+          className={styles.image}
+        />
+      )}
+      <div className={styles.info}>
+        <span className={styles.title}>
+          <Hl html={fmt.name || hit.name} />
+        </span>
+        {hasKnownFor && (
+          <div>
+            <div className={styles.label}>Known for</div>
+            <Hl
+              html={
+                Array.isArray(fmt.known_for)
+                  ? fmt.known_for.join(', ')
+                  : fmt.known_for ||
+                    (Array.isArray(hit.known_for)
+                      ? hit.known_for.join(', ')
+                      : hit.known_for)
+              }
+            />
+          </div>
+        )}
+        {fmt.biography && (
+          <div className={styles.overview}>
+            <Hl html={fmt.biography} />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const FederatedHit = ({ hit }) => {
+  const isMovie = hit._federation.indexUid === 'moviesTmdb'
+  return (
+    <div className={styles.card}>
+      <span
+        className={`${styles.badge} ${
+          isMovie ? styles.movieBadge : styles.actorBadge
+        }`}
+      >
+        {isMovie ? 'Movie' : 'Actor'}
+      </span>
+      {isMovie ? <MovieHit hit={hit} /> : <ActorHit hit={hit} />}
+    </div>
+  )
+}
+
+export default FederatedHit

--- a/src/federated-search/components/Results/FederatedResults.js
+++ b/src/federated-search/components/Results/FederatedResults.js
@@ -1,0 +1,68 @@
+import React, { useState, useEffect } from 'react'
+import { useInstantSearch } from 'react-instantsearch-hooks-web'
+import FederatedHit from './FederatedHit'
+import NoResults from './NoResults'
+import styles from '../../styles/FederatedResults.module.css'
+
+const FederatedResults = () => {
+  const { indexUiState } = useInstantSearch()
+  const query = indexUiState.query || ''
+  const [hits, setHits] = useState([])
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    setReady(false)
+    fetch(`${process.env.NEXT_PUBLIC_MEILISEARCH_HOST}/multi-search`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${process.env.NEXT_PUBLIC_MEILISEARCH_SEARCH_API_KEY}`,
+      },
+      body: JSON.stringify({
+        queries: [
+          {
+            indexUid: 'moviesTmdb',
+            q: query,
+            attributesToHighlight: ['title', 'overview'],
+            highlightPreTag: '<mark>',
+            highlightPostTag: '</mark>',
+          },
+          {
+            indexUid: 'actorsTmdb',
+            q: query,
+            attributesToHighlight: ['name', 'known_for'],
+            attributesToCrop: ['biography:80'],
+            highlightPreTag: '<mark>',
+            highlightPostTag: '</mark>',
+            cropMarker: '…',
+          },
+        ],
+        federation: { limit: 20, offset: 0 },
+      }),
+    })
+      .then(r => r.json())
+      .then(data => {
+        setHits(data.hits || [])
+        setReady(true)
+      })
+      .catch(() => setReady(true))
+  }, [query])
+
+  if (!ready) return null
+  if (hits.length === 0) return <NoResults />
+
+  return (
+    <ul className={styles.list}>
+      {hits.map((hit, i) => (
+        <li
+          key={`${hit._federation.indexUid}-${hit.id ?? i}`}
+          className={styles.item}
+        >
+          <FederatedHit hit={hit} />
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+export default FederatedResults

--- a/src/federated-search/next.config.js
+++ b/src/federated-search/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig

--- a/src/federated-search/pages/_document.js
+++ b/src/federated-search/pages/_document.js
@@ -1,4 +1,5 @@
 import { Html, Head, Main, NextScript } from 'next/document'
+import Script from 'next/script'
 
 export default function Document() {
   return (

--- a/src/federated-search/pages/index.js
+++ b/src/federated-search/pages/index.js
@@ -1,39 +1,53 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { InstantSearch, Index, Configure } from 'react-instantsearch-hooks-web'
 import { instantMeiliSearch } from '@meilisearch/instant-meilisearch'
 import Header from '../components/Header'
 import MovieResults from '../components/Results/MovieResults'
 import ActorResults from '../components/Results/ActorResults'
+import FederatedResults from '../components/Results/FederatedResults'
+import ModeToggle from '../components/ModeToggle'
 
 const searchClient = instantMeiliSearch(
   process.env.NEXT_PUBLIC_MEILISEARCH_HOST,
   process.env.NEXT_PUBLIC_MEILISEARCH_SEARCH_API_KEY
 )
 
-const App = () => (
-  <InstantSearch indexName="moviesTmdb" searchClient={searchClient}>
-    <Header />
-    <div class="title">
-      <h1>Federated search</h1>
-      <p>
-        Search across several indexes with Meilisearch&apos;s federated search
-      </p>
-    </div>
-    <div className="mainContainer centralWidth">
-      <div className="leftPanel">
-        <Configure hitsPerPage={10} />
-        <h2>Movies</h2>
-        <MovieResults />
+const App = () => {
+  const [mode, setMode] = useState('multi')
+
+  return (
+    <InstantSearch indexName="moviesTmdb" searchClient={searchClient}>
+      <Header />
+      <div className="title">
+        <h1>Meilisearch multi-search</h1>
+        <p>Search across movies and actors with and without federation</p>
       </div>
-      <div className="rightPanel">
-        <Index indexName="actorsTmdb">
-          <Configure hitsPerPage={10} attributesToSnippet={['biography:80']} />
-          <h2>Actors</h2>
-          <ActorResults />
-        </Index>
-      </div>
-    </div>
-  </InstantSearch>
-)
+      <ModeToggle mode={mode} onChange={setMode} />
+      {mode === 'multi' ? (
+        <div className="mainContainer centralWidth">
+          <div className="leftPanel">
+            <Configure hitsPerPage={10} />
+            <h2>Movies</h2>
+            <MovieResults />
+          </div>
+          <div className="rightPanel">
+            <Index indexName="actorsTmdb">
+              <Configure
+                hitsPerPage={10}
+                attributesToSnippet={['biography:80']}
+              />
+              <h2>Actors</h2>
+              <ActorResults />
+            </Index>
+          </div>
+        </div>
+      ) : (
+        <div className="centralWidth">
+          <FederatedResults />
+        </div>
+      )}
+    </InstantSearch>
+  )
+}
 
 export default App

--- a/src/federated-search/styles/FederatedHit.module.css
+++ b/src/federated-search/styles/FederatedHit.module.css
@@ -1,0 +1,88 @@
+.card {
+  position: relative;
+  background: #ffffff;
+  box-shadow: 0px 0px 30px rgba(57, 72, 110, 0.05);
+  border-radius: 8px;
+  padding: 1.5rem;
+}
+
+.badge {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.25rem 0.6rem;
+  border-radius: 99px;
+}
+
+.movieBadge {
+  background-color: var(--dodger-blue-100);
+  color: var(--dodger-blue-600);
+}
+
+.actorBadge {
+  background-color: var(--hot-pink-100);
+  color: var(--hot-pink-700);
+}
+
+.mainInfo {
+  overflow: hidden;
+}
+
+.image {
+  border-radius: 5px;
+  margin-right: 1.5em;
+  margin-bottom: 0.5em;
+  float: left;
+  width: 80px;
+  height: auto;
+}
+
+.info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.title {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--valhalla-500);
+  padding-right: 4rem;
+}
+
+.title mark {
+  background: var(--dodger-blue-100);
+  color: var(--dodger-blue-600);
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
+.genres {
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: 0.25rem;
+}
+
+.overview {
+  margin-top: 0.75rem;
+  clear: both;
+}
+
+.overview mark {
+  background: var(--dodger-blue-100);
+  color: var(--dodger-blue-600);
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
+.label {
+  font-weight: 700;
+  font-size: 0.8rem;
+  letter-spacing: 0.03rem;
+  text-transform: uppercase;
+  margin-top: 0.25rem;
+}

--- a/src/federated-search/styles/FederatedResults.module.css
+++ b/src/federated-search/styles/FederatedResults.module.css
@@ -1,0 +1,11 @@
+.list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-bottom: 2rem;
+}
+
+.item {
+  width: 100%;
+}

--- a/src/federated-search/styles/ModeToggle.module.css
+++ b/src/federated-search/styles/ModeToggle.module.css
@@ -1,0 +1,48 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 0 1.25rem;
+}
+
+.toggle {
+  display: flex;
+  background-color: var(--ashes-500);
+  border-radius: 8px;
+  padding: 4px;
+  gap: 4px;
+}
+
+.option {
+  padding: 0.45rem 1.5rem;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--valhalla-300);
+  font-family: 'Inter', sans-serif;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.option:hover {
+  background-color: var(--ashes-600);
+  color: var(--valhalla-500);
+}
+
+.active {
+  background-color: var(--white);
+  color: var(--dodger-blue-600);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  font-weight: 600;
+}
+
+.description {
+  font-size: 0.85rem;
+  color: var(--valhalla-200);
+  font-family: 'Poppins', sans-serif;
+  text-align: center;
+  max-width: 520px;
+}


### PR DESCRIPTION
# Pull Request

## Related issue
-

## What does this PR do?
This demo was previously labeled as federated search, but it was actually performing multi-search across two indexes rather than true federated search with a single aggregated result set.

- Introduces a new federated search mode on top of the existing multi-index demo
- Adds a toggle to switch between multi-search and federated search modes

